### PR TITLE
＜創業100年以上でzのつく自動車メーカー＞を＜創業100年以上でaのつく自動車メーカー＞に修正。それに伴い23行目も"z"⇨"a"に修正。ファイル末尾に空行を追加。

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/Main.java
+++ b/src/Main.java
@@ -16,13 +16,14 @@ public class Main {
             System.out.println(shop.getFounding() + "年創業");
         }
 
-        System.out.println("<創業100年以上でzのつく自動車メーカー>");
+        System.out.println("<創業100年以上でaのつく自動車メーカー>");
 
         carShops.stream()
                 .filter(carShop -> carShop.getFounding() <= 1923)
-                .filter(carShop -> carShop.getName().contains("z"))
+                .filter(carShop -> carShop.getName().contains("a"))
                 .map(carShop -> carShop.getName().toUpperCase())
                 .forEach(System.out::println);
 
     }
 }
+


### PR DESCRIPTION
# 概要
＜創業100年以上でzのつく自動車メーカー＞を＜創業100年以上でaのつく自動車メーカー＞に修正しました。それに伴い23行目も"z"⇨"a"に修正しています。ファイル末尾に１行空行を追加しました。


# 動作確認
![スクリーンショット 2023-08-13 16 03 35](https://github.com/kinta21/RaiseTech-Task5/assets/141032732/77eade53-2fbe-4775-ad77-0186bf57ab32)
